### PR TITLE
fix: Playing new song uses lyrics from previous song

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2380,6 +2380,9 @@ export default class ReactJkMusicPlayer extends PureComponent {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ isResetCoverRotate: true })
     }
+    if (prevState.lyric !== this.state.lyric) {
+      this.initLyricParser()
+    }
   }
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
Closes navidrome/navidrome#2117

Fixes issue where lyric is not updated after switching song and uses lyrics from previous song.
![lyrics_bug_fixed](https://user-images.githubusercontent.com/24394068/215297819-87fd03a1-41fc-49b5-9528-07c0b5fecd47.gif)
