### PR TITLE
fix: lyrics overlap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1338,8 +1338,8 @@ export default class ReactJkMusicPlayer extends PureComponent {
   onAudioPause = () => {
     this.setState({ playing: false })
     this.props.onAudioPause && this.props.onAudioPause(this.getBaseAudioInfo())
-    if (this.state.lyric && this.lyric) {
-      this.lyric.togglePlay()
+    if (this.lyric) {
+      this.lyric.pause()
     }
   }
 
@@ -1546,6 +1546,8 @@ export default class ReactJkMusicPlayer extends PureComponent {
     const { restartCurrentOnPrev } = this.props
     if (restartCurrentOnPrev && this.audio.currentTime > 1) {
       this.audio.currentTime = 0
+      this.initLyricParser()
+      this.lyric.seek(0)
       return
     }
 
@@ -1981,6 +1983,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
   }
 
   initLyricParser = () => {
+    this.removeLyric()
     this.lyric = new Lyric(this.state.lyric, this.onLyricChange)
     this.setState({
       currentLyric: this.lyric.lines[0] && this.lyric.lines[0].text,

--- a/src/lyric.js
+++ b/src/lyric.js
@@ -128,6 +128,14 @@ export default class Lyric {
     }
   }
 
+  pause() {
+    const now = +new Date()
+    if (this.state === STATE_PLAYING) {
+      this.stop()
+      this.pauseStamp = now
+    }
+  }
+
   stop() {
     this.state = STATE_PAUSE
     clearTimeout(this.timer)


### PR DESCRIPTION
Closes navidrome/navidrome#2218

Fixes issue where lyrics of previous track overlap with current track if you press the "next track" button.
Also fixes issue with pressing the "previous track" button showing same lyrics at wrong time.