### PR TITLE
Support for lyrics with multiple lines

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -694,7 +694,11 @@ export default class ReactJkMusicPlayer extends PureComponent {
         {audioLyricVisible && (
           <Draggable>
             <div className={cls('music-player-lyric', lyricClassName)}>
-              {currentLyric || locale.emptyLyricText}
+              {this.state.lyric
+                ? (currentLyric || '')
+                    .split('\n')
+                    .map((s) => <div key={s}>{s}</div>)
+                : locale.emptyLyricText}
             </div>
           </Draggable>
         )}

--- a/src/lyric.js
+++ b/src/lyric.js
@@ -43,6 +43,7 @@ export default class Lyric {
   _initLines() {
     const lines = this.lrc.split('\n')
     const offset = parseInt(this.tags.offset, 10) || 0
+    let lineCount = 0
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       const result = timeExp.exec(line)
@@ -56,14 +57,26 @@ export default class Lyric {
               (result[3] || 0) * 10 +
               offset,
             txt,
+            num: lineCount++,
           })
         }
       }
     }
 
     this.lines.sort((a, b) => {
-      return a.time - b.time
+      const cp = a.time - b.time
+      if (cp === 0.0) {
+        return a.num - b.num
+      }
+      return cp
     })
+    
+    for (let i = this.lines.length - 2; i >= 0; i--) {
+      if (this.lines[i].time === this.lines[i + 1].time) {
+        this.lines[i].txt += `\n${this.lines[i + 1].txt}`
+        this.lines.splice(i + 1, 1)
+      }
+    }
   }
 
   _findCurNum(time) {


### PR DESCRIPTION
Close an issue that is closed by a bot ^_^. [#1864](https://github.com/navidrome/navidrome/issues/1864).

When there are two lines of lyrics with the same time tag, I made them to be displayed at the same time.

Like the screenshot below:

<img width="991" alt="图片" src="https://github.com/navidrome/react-music-player/assets/2764768/a53120e2-c254-4036-802a-66b9097d41d2">
