### PR TITLE
feat: add rewind, foward to music player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage
 example/dist
 .vscode
 main.js
+.yarn
+.yarnrc.yml

--- a/__tests__/tests/__snapshots__/icon.test.js.snap
+++ b/__tests__/tests/__snapshots__/icon.test.js.snap
@@ -91,12 +91,50 @@ exports[`Player custom icon test should render custom icon 1`] = `
             </div>
           </span>
           <span
+            class="group rewind-btn"
+            title="Rewind"
+          >
+            <svg
+              class="react-jinke-music-player-pause-icon"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.5 280.6l192 160c20.6 17.2 52.5 2.8 52.5-24.6V96c0-27.4-31.9-41.8-52.5-24.6l-192 160c-15.3 12.8-15.3 36.4 0 49.2zm256 0l192 160c20.6 17.2 52.5 2.8 52.5-24.6V96c0-27.4-31.9-41.8-52.5-24.6l-192 160c-15.3 12.8-15.3 36.4 0 49.2z"
+              />
+            </svg>
+          </span>
+          <span
             class="group play-btn"
             title="Click to play"
           >
             <div>
               1
             </div>
+          </span>
+          <span
+            class="group forward-btn"
+            title="Forward"
+          >
+            <svg
+              class="react-jinke-music-player-pause-icon"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M500.5 231.4l-192-160C287.9 54.3 256 68.6 256 96v320c0 27.4 31.9 41.8 52.5 24.6l192-160c15.3-12.8 15.3-36.4 0-49.2zm-256 0l-192-160C31.9 54.3 0 68.6 0 96v320c0 27.4 31.9 41.8 52.5 24.6l192-160c15.3-12.8 15.3-36.4 0-49.2z"
+              />
+            </svg>
           </span>
           <span
             class="group next-audio"
@@ -486,12 +524,50 @@ exports[`Player custom icon test should render custom icon in mobile mode 1`] = 
         </div>
       </span>
       <span
+        class="group rewind-btn"
+        title="Rewind"
+      >
+        <svg
+          class="react-jinke-music-player-pause-icon"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 512 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.5 280.6l192 160c20.6 17.2 52.5 2.8 52.5-24.6V96c0-27.4-31.9-41.8-52.5-24.6l-192 160c-15.3 12.8-15.3 36.4 0 49.2zm256 0l192 160c20.6 17.2 52.5 2.8 52.5-24.6V96c0-27.4-31.9-41.8-52.5-24.6l-192 160c-15.3 12.8-15.3 36.4 0 49.2z"
+          />
+        </svg>
+      </span>
+      <span
         class="group play-btn"
         title="Click to play"
       >
         <div>
           1
         </div>
+      </span>
+      <span
+        class="group forward-btn"
+        title="Forward"
+      >
+        <svg
+          class="react-jinke-music-player-pause-icon"
+          fill="currentColor"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 512 512"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M500.5 231.4l-192-160C287.9 54.3 256 68.6 256 96v320c0 27.4 31.9 41.8 52.5 24.6l192-160c15.3-12.8 15.3-36.4 0-49.2zm-256 0l-192-160C31.9 54.3 0 68.6 0 96v320c0 27.4 31.9 41.8 52.5 24.6l192-160c15.3-12.8 15.3-36.4 0-49.2z"
+          />
+        </svg>
       </span>
       <span
         class="group next-audio"

--- a/__tests__/tests/__snapshots__/locale.test.js.snap
+++ b/__tests__/tests/__snapshots__/locale.test.js.snap
@@ -30,6 +30,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
         size={26}
       />,
       "empty": <MdLibraryMusic />,
+      "forward": <AnimateForwardIcon />,
       "loading": <FaSpinner />,
       "loop": <MdRepeatOne
         size={26}
@@ -55,6 +56,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
       "reload": <FaSyncAlt
         size={22}
       />,
+      "rewind": <AnimateRewindIcon />,
       "shuffle": <TiArrowShuffle
         size={26}
       />,
@@ -442,6 +444,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
               size={26}
             />,
             "empty": <MdLibraryMusic />,
+            "forward": <AnimateForwardIcon />,
             "loading": <Spin />,
             "loop": <MdRepeatOne
               size={26}
@@ -467,6 +470,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
             "reload": <FaSyncAlt
               size={22}
             />,
+            "rewind": <AnimateRewindIcon />,
             "shuffle": <TiArrowShuffle
               size={26}
             />,
@@ -490,6 +494,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
             "downloadText": "Download",
             "emptyLyricText": "No lyric",
             "emptyText": "No music",
+            "forwardAudioText": "Forward",
             "lightThemeText": "L",
             "loadingText": "Loading",
             "nextTrackText": "Next track",
@@ -504,6 +509,7 @@ exports[`Locale test should render default locale with en_US 1`] = `
             "previousTrackText": "Previous track",
             "reloadText": "Reload",
             "removeAudioListsText": "Delete audio lists",
+            "rewindAudioText": "Rewind",
             "switchThemeText": "Dark/Light mode",
             "toggleLyricText": "Toggle lyric",
             "toggleMiniModeText": "Minimize",
@@ -725,6 +731,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
         size={26}
       />,
       "empty": <MdLibraryMusic />,
+      "forward": <AnimateForwardIcon />,
       "loading": <FaSpinner />,
       "loop": <MdRepeatOne
         size={26}
@@ -750,6 +757,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
       "reload": <FaSyncAlt
         size={22}
       />,
+      "rewind": <AnimateRewindIcon />,
       "shuffle": <TiArrowShuffle
         size={26}
       />,
@@ -1302,6 +1310,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
               size={26}
             />,
             "empty": <MdLibraryMusic />,
+            "forward": <AnimateForwardIcon />,
             "loading": <Spin />,
             "loop": <MdRepeatOne
               size={26}
@@ -1327,6 +1336,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
             "reload": <FaSyncAlt
               size={22}
             />,
+            "rewind": <AnimateRewindIcon />,
             "shuffle": <TiArrowShuffle
               size={26}
             />,
@@ -1350,6 +1360,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
             "downloadText": "下载",
             "emptyLyricText": "暂无歌词",
             "emptyText": "音乐播放列表为空",
+            "forwardAudioText": "向前",
             "lightThemeText": "亮",
             "loadingText": "加载中",
             "nextTrackText": "下一首",
@@ -1364,6 +1375,7 @@ exports[`Locale test should render locale with zh_CN 1`] = `
             "previousTrackText": "上一首",
             "reloadText": "重新播放",
             "removeAudioListsText": "清空播放列表",
+            "rewindAudioText": "倒带",
             "switchThemeText": "暗黑/明亮 主题",
             "toggleLyricText": "显示/隐藏 歌词",
             "toggleMiniModeText": "切换至迷你模式",

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { FaPauseCircle } from '@react-icons/all-files/fa/FaPauseCircle'
 import { FaPlayCircle } from '@react-icons/all-files/fa/FaPlayCircle'
+import { FaForward } from '@react-icons/all-files/fa/FaForward'
+import { FaBackward } from '@react-icons/all-files/fa/FaBackward'
 
 export { FaBook as LyricIcon } from '@react-icons/all-files/fa/FaBook'
 export { FaHeadphones as FaHeadphonesIcon } from '@react-icons/all-files/fa/FaHeadphones'
@@ -28,4 +30,10 @@ export const AnimatePlayIcon = () => (
 )
 export const AnimatePauseIcon = () => (
   <FaPauseCircle className="react-jinke-music-player-pause-icon" />
+)
+export const AnimateForwardIcon = () => (
+  <FaForward className="react-jinke-music-player-pause-icon" />
+)
+export const AnimateRewindIcon = () => (
+  <FaBackward className="react-jinke-music-player-pause-icon" />
 )

--- a/src/components/PlayerMobile.js
+++ b/src/components/PlayerMobile.js
@@ -23,6 +23,8 @@ const PlayerMobile = ({
   currentPlayModeName,
   extendsContent,
   onPlay,
+  onRewind,
+  onForward,
   glassBg,
   onCoverClick,
   autoHiddenCover,
@@ -88,17 +90,33 @@ const PlayerMobile = ({
       {loading ? (
         <span className="group loading-icon">{icon.loading}</span>
       ) : (
-        <span
-          className="group play-btn"
-          title={
-            shouldShowPlayIcon
-              ? locale.clickToPlayText
-              : locale.clickToPauseText
-          }
-          onClick={onPlay}
-        >
-          {shouldShowPlayIcon ? icon.play : icon.pause}
-        </span>
+        <>
+          <span
+            className="group rewind-btn"
+            title={locale.rewindAudioText}
+            onClick={onRewind}
+          >
+            {icon.rewind}
+          </span>
+          <span
+            className="group play-btn"
+            title={
+              shouldShowPlayIcon
+                ? locale.clickToPlayText
+                : locale.clickToPauseText
+            }
+            onClick={onPlay}
+          >
+            {shouldShowPlayIcon ? icon.play : icon.pause}
+          </span>
+          <span
+            className="group forward-btn"
+            title={locale.forwardAudioText}
+            onClick={onForward}
+          >
+            {icon.forward}
+          </span>
+        </>
       )}
       <span
         className="group next-audio"

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ import Sortable, { Swap } from 'sortablejs'
 import AudioListsPanel from './components/AudioListsPanel'
 import CircleProcessBar from './components/CircleProcessBar'
 import {
+  AnimateRewindIcon,
+  AnimateForwardIcon,
   AnimatePauseIcon,
   AnimatePlayIcon,
   ArrowDownIcon,
@@ -93,6 +95,8 @@ const DEFAULT_ICON = {
   loading: <LoadIcon />,
   packUpPanelMobile: <ArrowDownIcon size={26} />,
   empty: <EmptyIcon />,
+  forward: <AnimateForwardIcon />,
+  rewind: <AnimateRewindIcon />,
 }
 
 export default class ReactJkMusicPlayer extends PureComponent {
@@ -496,6 +500,8 @@ export default class ReactJkMusicPlayer extends PureComponent {
             currentTime={formattedCurrentTime}
             progressBar={ProgressBar}
             onPlay={this.onTogglePlay}
+            onRewind={this.onAudioRewind}
+            onForward={this.onAudioForward}
             currentPlayModeName={currentPlayModeName}
             playMode={PlayModeComponent}
             audioNextPlay={this.onPlayNextAudio}
@@ -586,19 +592,35 @@ export default class ReactJkMusicPlayer extends PureComponent {
                         {this.iconMap.loading}
                       </span>
                     ) : (
-                      <span
-                        className="group play-btn"
-                        onClick={this.onTogglePlay}
-                        title={
-                          shouldShowPlayIcon
-                            ? locale.clickToPlayText
-                            : locale.clickToPauseText
-                        }
-                      >
-                        {shouldShowPlayIcon
-                          ? this.iconMap.play
-                          : this.iconMap.pause}
-                      </span>
+                      <>
+                        <span
+                          className="group rewind-btn"
+                          onClick={this.onAudioRewind}
+                          title={locale.rewindAudioText}
+                        >
+                          {this.iconMap.rewind}
+                        </span>
+                        <span
+                          className="group play-btn"
+                          onClick={this.onTogglePlay}
+                          title={
+                            shouldShowPlayIcon
+                              ? locale.clickToPlayText
+                              : locale.clickToPauseText
+                          }
+                        >
+                          {shouldShowPlayIcon
+                            ? this.iconMap.play
+                            : this.iconMap.pause}
+                        </span>
+                        <span
+                          className="group forward-btn"
+                          onClick={this.onAudioForward}
+                          title={locale.forwardAudioText}
+                        >
+                          {this.iconMap.forward}
+                        </span>
+                      </>
                     )}
                     <span
                       className="group next-audio"
@@ -1326,6 +1348,14 @@ export default class ReactJkMusicPlayer extends PureComponent {
       }
       this.loadAndPlayAudio(isLoaded)
     }
+  }
+
+  onAudioForward = () => {
+    this.audio.currentTime += 10
+  }
+
+  onAudioRewind = () => {
+    this.audio.currentTime -= 10
   }
 
   setAudioLoaded = () => {

--- a/src/locale/en_US.js
+++ b/src/locale/en_US.js
@@ -15,6 +15,8 @@ export default {
   clickToPauseText: 'Click to pause',
   nextTrackText: 'Next track',
   previousTrackText: 'Previous track',
+  rewindAudioText: 'Rewind',
+  forwardAudioText: 'Forward',
   reloadText: 'Reload',
   volumeText: 'Volume',
   playListsText: 'Playlists',

--- a/src/locale/zh_CN.js
+++ b/src/locale/zh_CN.js
@@ -15,6 +15,8 @@ export default {
   clickToPauseText: '点击暂停',
   nextTrackText: '下一首',
   previousTrackText: '上一首',
+  rewindAudioText: '倒带',
+  forwardAudioText: '向前',
   reloadText: '重新播放',
   volumeText: '音量',
   playListsText: '播放列表',

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -266,7 +266,6 @@
       }
 
       .player-content {
-        padding-left: 5%;
         display: inline-flex;
         align-items: center;
         align-content: center;
@@ -328,7 +327,7 @@
           padding: 0 18px;
         }
 
-        .play-btn {
+        .play-btn, .forward-btn, .rewind-btn {
           padding: 0 18px;
 
           svg {

--- a/src/styles/playerMobile.less
+++ b/src/styles/playerMobile.less
@@ -197,7 +197,7 @@
         font-size: 40px;
       }
     }
-    .play-btn {
+    .play-btn, .forward-btn, .rewind-btn{
       padding: 0 40px;
       svg {
         font-size: 45px;
@@ -214,7 +214,7 @@
           font-size: 32px;
         }
       }
-      .play-btn {
+      .play-btn, .forward-btn, .rewind-btn {
         svg {
           font-size: 40px;
         }


### PR DESCRIPTION
### Description 
Add controls to forward 10s and rewind 10s. 
### Screenshots
#### Mobile view
![Mobile view](https://github.com/navidrome/react-music-player/assets/49572404/3a448442-5d27-4f98-8b83-f15ed80abfa5)
#### Desktop view
![Desktop view](https://github.com/navidrome/react-music-player/assets/49572404/b9cf1d6b-7cd0-40c7-9d7e-c234a3b9dc7a)

### Related Issue
This PR is related to the discussion [navidrome-discussion](https://github.com/navidrome/navidrome/issues/1755)
