### PR TITLE
fix: keep lyrics in sync on track change and seek

### DIFF
--- a/__tests__/tests/lyric-parser.test.js
+++ b/__tests__/tests/lyric-parser.test.js
@@ -1,0 +1,52 @@
+import Lyric from '../../src/lyric'
+
+const LRC = ['[00:19.38] L1', '[00:24.68] L2', '[00:30.11] L3'].join('\n')
+
+describe('Lyric parser', () => {
+  describe('update() drives position from an external clock', () => {
+    it('clears the display before the first line', () => {
+      const calls = []
+      const p = new Lyric(LRC, (a) => calls.push(a))
+      p.update(5000) // before first line at 19.38s
+      expect(calls[calls.length - 1]).toEqual({ txt: '', lineNum: -1 })
+    })
+
+    it('shows the active line for the current time', () => {
+      const calls = []
+      const p = new Lyric(LRC, (a) => calls.push(a))
+      p.update(26000) // between L2 (24.68s) and L3 (30.11s) -> L2 active
+      expect(calls[calls.length - 1]).toEqual({ txt: 'L2', lineNum: 1 })
+    })
+
+    it('does not re-fire when the active line is unchanged', () => {
+      const calls = []
+      const p = new Lyric(LRC, (a) => calls.push(a))
+      p.update(26000)
+      const n = calls.length
+      p.update(27000) // still within L2
+      expect(calls.length).toBe(n)
+    })
+
+    it('re-selects the earlier line when seeking backward (no drift)', () => {
+      const calls = []
+      const p = new Lyric(LRC, (a) => calls.push(a))
+      p.update(31000) // L3 active
+      p.update(20000) // rewind -> L1 active
+      expect(calls[calls.length - 1]).toEqual({ txt: 'L1', lineNum: 0 })
+    })
+
+    it('is a no-op when there are no lines', () => {
+      const calls = []
+      const p = new Lyric('', (a) => calls.push(a))
+      p.update(5000)
+      expect(calls).toHaveLength(0)
+    })
+  })
+
+  describe('stop() halts the parser', () => {
+    it('does not throw and leaves no pending timer', () => {
+      const p = new Lyric(LRC)
+      expect(() => p.stop()).not.toThrow()
+    })
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1996,9 +1996,11 @@ export default class ReactJkMusicPlayer extends PureComponent {
     // lines into the shared currentLyric (navidrome #5661).
     this.lyric && this.lyric.stop()
     this.lyric = new Lyric(this.state.lyric, this.onLyricChange)
-    this.setState({
-      currentLyric: this.lyric.lines[0] && this.lyric.lines[0].txt,
-    })
+    // Start empty, then let the parser pick the line for the current position
+    // (empty before the first line). Seeding lines[0] unconditionally would show
+    // a line that isn't active yet when loaded paused or re-inited mid-playback.
+    this.setState({ currentLyric: '' })
+    this.lyric.update((this.audio ? this.audio.currentTime : 0) * 1000)
   }
 
   onLyricChange = ({ lineNum, txt }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
       loadedProgress,
       audioLists,
       removeId,
+      lyric,
       currentLyric,
       audioLyricVisible,
       isPlayDestroyed,
@@ -695,7 +696,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
         {audioLyricVisible && (
           <Draggable>
             <div className={cls('music-player-lyric', lyricClassName)}>
-              {currentLyric || locale.emptyLyricText}
+              {currentLyric || (lyric ? '♪' : locale.emptyLyricText)}
             </div>
           </Draggable>
         )}
@@ -1339,9 +1340,6 @@ export default class ReactJkMusicPlayer extends PureComponent {
   onAudioPause = () => {
     this.setState({ playing: false })
     this.props.onAudioPause && this.props.onAudioPause(this.getBaseAudioInfo())
-    if (this.state.lyric && this.lyric) {
-      this.lyric.togglePlay()
-    }
   }
 
   onAudioPlay = () => {
@@ -1351,9 +1349,6 @@ export default class ReactJkMusicPlayer extends PureComponent {
     }
     this.setState({ playing: true, loading: false })
     this.props.onAudioPlay && this.props.onAudioPlay(this.getBaseAudioInfo())
-    if (this.state.lyric && this.lyric) {
-      this.lyric.togglePlay()
-    }
   }
 
   onSetAudioLoadedProgress = () => {
@@ -1560,6 +1555,10 @@ export default class ReactJkMusicPlayer extends PureComponent {
   audioTimeUpdate = () => {
     const { currentTime } = this.audio
     this.setState({ currentTime })
+    // Drive the lyric position from the audio's real clock. This is the single
+    // source of truth, so the display self-corrects after seeks and buffering
+    // instead of drifting on the parser's own setTimeout clock.
+    this.lyric && this.lyric.update(currentTime * 1000)
     if (this.props.remember) {
       this.saveLastPlayStatus()
     }
@@ -1594,6 +1593,9 @@ export default class ReactJkMusicPlayer extends PureComponent {
     if (this.audio) {
       this.audio.currentTime = currentTime
     }
+    // Reposition the lyric while scrubbing: timeupdate does not fire when the
+    // audio is paused, so without this the panel would freeze on the old line.
+    this.lyric && this.lyric.update(currentTime * 1000)
     this.setState({ currentTime, isAudioSeeking: true })
   }
 
@@ -1602,14 +1604,12 @@ export default class ReactJkMusicPlayer extends PureComponent {
     if (!this.state.audioLists.length) {
       return
     }
-    this.lyric && this.lyric.seek(currentTime * 1000)
-
-    if (!this.state.playing) {
-      this.lyric && this.lyric.stop()
-    }
     if (this.audio) {
       this.audio.currentTime = currentTime
     }
+    // Reposition the lyric to the seek target now. While playing, the next
+    // timeupdate would also do this, but timeupdate does not fire while paused.
+    this.lyric && this.lyric.update(currentTime * 1000)
 
     this.props.onAudioSeeked &&
       this.props.onAudioSeeked(this.getBaseAudioInfo())
@@ -1990,9 +1990,14 @@ export default class ReactJkMusicPlayer extends PureComponent {
   }
 
   initLyricParser = () => {
+    // Stop any previous parser before replacing it. Otherwise its setTimeout
+    // chain keeps firing onLyricChange after this.lyric is overwritten, so
+    // rapid track changes leave orphaned parsers writing the previous song's
+    // lines into the shared currentLyric (navidrome #5661).
+    this.lyric && this.lyric.stop()
     this.lyric = new Lyric(this.state.lyric, this.onLyricChange)
     this.setState({
-      currentLyric: this.lyric.lines[0] && this.lyric.lines[0].text,
+      currentLyric: this.lyric.lines[0] && this.lyric.lines[0].txt,
     })
   }
 

--- a/src/lyric.js
+++ b/src/lyric.js
@@ -21,6 +21,8 @@ export default class Lyric {
     this.handler = handler
     this.state = STATE_PAUSE
     this.curLine = 0
+    // Sentinel distinct from -1 so the first update() always emits.
+    this._lastActive = -2
 
     this._init()
   }
@@ -135,5 +137,37 @@ export default class Lyric {
 
   seek(offset) {
     this.play(offset)
+  }
+
+  // Position the lyric purely from an externally supplied time (the audio
+  // element's real currentTime), independent of any setTimeout clock. Called on
+  // every timeupdate so the display self-corrects after seeks and buffering.
+  // Emits an empty line before the first lyric so stale text is never left on
+  // screen. Only fires the handler when the active line actually changes.
+  update(timeMs) {
+    if (!this.lines.length) {
+      return
+    }
+    let lo = 0
+    let hi = this.lines.length - 1
+    let active = -1
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2)
+      if (this.lines[mid].time <= timeMs) {
+        active = mid
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+    if (active === this._lastActive) {
+      return
+    }
+    this._lastActive = active
+    if (active < 0) {
+      this.handler({ txt: '', lineNum: -1 })
+    } else {
+      this.handler({ txt: this.lines[active].txt, lineNum: active })
+    }
   }
 }


### PR DESCRIPTION
Drives the lyric position from the audio element's `currentTime` instead of an independent `setTimeout` clock that drifted out of sync.

### Changes
- **Stop the previous parser** in `initLyricParser` before creating a new one, so rapid track switches no longer leave orphaned timers writing the previous song's lines into the panel.
- **Add `Lyric.update(timeMs)`** and call it from `audioTimeUpdate`, `onProgressChange`, and `onAudioSeeked`, so the displayed line tracks the audio after seeks — including while paused, where `timeupdate` does not fire.
- **Show a `♪` placeholder** during intros/gaps when the track has lyrics but no line is active yet, instead of the "no lyrics" message.
- **Fix wrong line field** in `initLyricParser` (`.text` → `.txt`) so the first line shows immediately on load.

### Testing
Adds `__tests__/tests/lyric-parser.test.js` for `Lyric.update()`. Validated manually in Navidrome: rapid track switching no longer interleaves two songs' lyrics; seeking/scrubbing (playing and paused) keeps the line in sync; intro shows `♪`, no-lyrics tracks still show the empty message.