### PR TITLE
 Fix cover image not being circular

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -557,6 +557,7 @@
       &-cover {
         border: 5px solid transparent;
         box-shadow: 0 0 30px 2px rgba(0, 0, 0, 0.2);
+        aspect-ratio: 1/1;
       }
 
       .current-time,


### PR DESCRIPTION
The cover image will in some cases differ in size and not be rendered properly as a perfect circle (or square). The mobile styles enforce an exact width and don't suffer from this issue.

This is fixed by setting the aspect-ratio of the cover image's container to 1:1.